### PR TITLE
use worker to copy files from yarn cache to node_modules folders

### DIFF
--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -33,6 +33,7 @@ fi
 [[ "$version" == "$(node artifacts/yarn-legacy-$version.js --version)" ]] || exit 1
 
 cp package.json dist/
+cp worker.js dist/worker.js
 cp README.md dist/
 cp LICENSE dist/
 # Only use the legacy version for NPM builds so we are compatible

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,20 @@
+const { parentPort } = require("worker_threads");
+const fs = require("fs");
+
+parentPort.on("message", (o) => {
+  try {
+    let running = o.actions.length;
+    o.actions.forEach(a => {
+      fs.copyFile(a.src, a.dest, 0, err => {
+        if (err) {
+          o.port.emit("error", err);
+        } else {
+          running -= 1;
+          running === 0 && o.port.postMessage("");
+        }
+      });
+    })
+  } catch (e) {
+        o.port.emit("error", e);
+  }
+})


### PR DESCRIPTION
The speed bottleneck when copying the files from the yarn cache to the node_modules folders is currently the CPU and not the disk. By spreading the load on 4 workers, this allows the CPU to run fast enough so it can keep up with the disk speed.