### PR TITLE
Revert "remove timeout because the bug it prevented is now fixed"

### DIFF
--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -390,7 +390,35 @@ export default class RequestManager {
     );
 
     const promise = new Promise((resolve, reject) => {
-      this.queue.push({params, reject, resolve});
+
+      /*
+       * This is a workaround for a bug that we have not been able to track down.
+       *
+       * Sometimes yarn would quit in the middle of fetching the packages
+       * with an exit code of 0. This typically happens when node has no more external resources or timeouts
+       * to wait for. This is an issue because yarn reports a success but the dependencies are
+       * not installed.
+       *
+       * A timeout prevents node from successfully exiting when this bug hits.
+       * When a promise takes more than 10min to resolve, we are likely hitting this bug, we then hard fail
+       * to properly report the failure.
+       */
+      const t = setTimeout(() => {
+        throw new Error(`Fetching/extracting of package ${params.url} seems to be hanging.`);
+
+      }, 10 * 60 * 1000);
+
+
+      const rej = (...args) => {
+        reject(...args);
+        clearTimeout(t);
+      }
+      const res = (...args) => {
+        resolve(...args);
+        clearTimeout(t);
+      }
+
+      this.queue.push({params, reject: rej, resolve: res});
       this.shiftQueue();
     });
 


### PR DESCRIPTION
There is still a bug which makes yarn quit earlier if we don't have these timeouts. So we re-introduce them. We will follow up to find this bug.