### PR TITLE
hard exit at the end of the install

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -139,7 +139,7 @@ export async function main({
   // if -v is the first command, then always exit after returning the version
   if (args[0] === '-v') {
     console.log(version.trim());
-    process.exitCode = 0;
+    process.exit(0)
     return;
   }
 
@@ -256,8 +256,8 @@ export async function main({
   });
 
   const exit = exitCode => {
-    process.exitCode = exitCode || 0;
     reporter.close();
+    process.exit(exitCode || 0);
   };
 
   reporter.initPeakMemoryCounter();


### PR DESCRIPTION
Currently yarn never calls exit, it simply exits when the event loop is empty. This is a problem because a package can be successfully resolved while one of the two racing requests takes a very long time and while doing prevents node from exiting.

In this change we explicitly exit node when yarn wants to exit