### PR TITLE
Revert "hard exit at the end of the install"

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -139,7 +139,7 @@ export async function main({
   // if -v is the first command, then always exit after returning the version
   if (args[0] === '-v') {
     console.log(version.trim());
-    process.exit(0)
+    process.exitCode = 0;
     return;
   }
 
@@ -256,8 +256,8 @@ export async function main({
   });
 
   const exit = exitCode => {
+    process.exitCode = exitCode || 0;
     reporter.close();
-    process.exit(exitCode || 0);
   };
 
   reporter.initPeakMemoryCounter();


### PR DESCRIPTION
This reverts commit 863b11292e68e055684f8e85fce00bb7b853ee75.

This cause yarn to exit on certain commands before it is done printing its output to console. This means that some console output will be truncated.