### PR TITLE
Always kill workers to avoid hangs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "midgard-yarn",
   "installationMethod": "unknown",
-  "version": "1.23.13",
+  "version": "1.23.14",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -558,23 +558,23 @@ export async function copyBulk(
 
   await new Promise((resolve, reject) => {
     const split = fileActions
-    .reduce(
-      (acc, curr) => {
-        if (acc[acc.length - 1].length < 50) {
-          acc[acc.length - 1].push(curr);
-        } else {
-          acc.push([curr]);
-        }
-        return acc;
-      },
-      [[]],
-    )
-    .filter(ac => ac && ac.length);
+      .reduce(
+        (acc, curr) => {
+          if (acc[acc.length - 1].length < 50) {
+            acc[acc.length - 1].push(curr);
+          } else {
+            acc.push([curr]);
+          }
+          return acc;
+        },
+        [[]],
+      )
+      .filter(ac => ac && ac.length);
 
     if (!split.length) {
       resolve();
     }
-    
+
     let running = 0;
     split.forEach(ac => {
       const worker = workers[next % workers.length];

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -558,23 +558,23 @@ export async function copyBulk(
 
   await new Promise((resolve, reject) => {
     const split = fileActions
-      .reduce(
-        (acc, curr) => {
-          if (acc[acc.length - 1].length < 50) {
-            acc[acc.length - 1].push(curr);
-          } else {
-            acc.push([curr]);
-          }
-          return acc;
-        },
-        [[]],
-      )
-      .filter(ac => ac && ac.length);
+    .reduce(
+      (acc, curr) => {
+        if (acc[acc.length - 1].length < 50) {
+          acc[acc.length - 1].push(curr);
+        } else {
+          acc.push([curr]);
+        }
+        return acc;
+      },
+      [[]],
+    )
+    .filter(ac => ac && ac.length);
 
     if (!split.length) {
       resolve();
     }
-
+    
     let running = 0;
     split.forEach(ac => {
       const worker = workers[next % workers.length];
@@ -593,9 +593,9 @@ export async function copyBulk(
       running += 1;
       worker.postMessage({actions: ac.map(a => ({src: a.src, dest: a.dest})), port: port2}, [port2]);
     });
-  });
+  })
+  .finally(() => killWorkers(workers));
 
-  killWorkers(workers);
 
   // we need to copy symlinks last as they could reference files we were copying
   const symlinkActions: Array<CopySymlinkAction> = actions.symlink;


### PR DESCRIPTION
If there are errors in the worker promise (which there are somewhere, still trying to work that out), then the onReject will cause the promise to reject, but workers will stay alive.

With this change, we kill the workers no matter what once the promise finishes. I expect whatever other failure that is causing the hang weill also surface, so I can chase that down after this safety is added