### PR TITLE
Use fs-normalized to get value of tracking times and unlinks

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -590,12 +590,11 @@ export async function copyBulk(
       };
       port1.on('error', onError);
       port1.on('message', onMessage);
+      port1.on('close', () => onError('copyBulk: worker closed port early.'));
       running += 1;
-      worker.postMessage({actions: ac.map(a => ({src: a.src, dest: a.dest})), port: port2}, [port2]);
+      worker.postMessage({actions: ac, port: port2}, [port2]);
     });
-  })
-  .finally(() => killWorkers(workers));
-
+  }).finally(() => killWorkers(workers));
 
   // we need to copy symlinks last as they could reference files we were copying
   const symlinkActions: Array<CopySymlinkAction> = actions.symlink;

--- a/worker.js
+++ b/worker.js
@@ -1,24 +1,19 @@
 // @flow
 const {parentPort} = require('worker_threads');
-const fs = require('fs');
+const fs = require('../lib/util/fs-normalized');
 
-parentPort.on('message', o => {
+parentPort.on('message', async o => {
   try {
     let running = o.actions.length;
     // Safety short circuit in case we somehow start a worker with nothing.
     running === 0 && o.port.postMessage('');
 
-    o.actions.forEach(a => {
-      fs.copyFile(a.src, a.dest, 0, err => {
-        if (err) {
-          o.port.emit('error', err);
-        } else {
-          running -= 1;
-          running === 0 && o.port.postMessage('');
-        }
-      });
-    });
+    const onSuccess = () => running === 0 && o.port.postMessage('');
+    const onError = err => o.port.emit('error', err);
+
+    await Promise.all(o.actions.map(a => fs.copyFile(a, () => running--).then(onSuccess).catch(onError)));
   } catch (e) {
-    o.port.emit('error', e);
+    // Forcefully close the worker if something failed.
+    o.port.close();
   }
 });


### PR DESCRIPTION
@VincentBailly it is still a bit unclear to me when these sporadic hangs are happening. I am sometimes able to get a hang by forcing `o.port.emit('error', err)` to run in the catch block. This will cause worker to explode and then hang. 

As a fix to that, I am instead closing the worker gracefully on such error, and treating a close on the fs.js side as an error case.

Other change that may be the culprit: fs-normalized's copy does some extra work to unlink old files and modify utimes/mtimes. I am not exactly sure if this would help, but I dont see a reason to not use this abstracted version (also converting to promises makes it more readable to me).

One thing I need help on here: I know you do some special handling copying the worker around in the prod build - so I am not sure if the require to fs-normalized will work as expected. What is below works for `yarn watch` command , but I am currently on windows and would need to change setups to test the build-dist script