### PR TITLE
use a queue for workers so workers have only one job at the time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "midgard-yarn",
   "installationMethod": "unknown",
-  "version": "1.23.14",
+  "version": "1.23.15",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",

--- a/worker.js
+++ b/worker.js
@@ -6,19 +6,19 @@ parentPort.on('message', o => {
   try {
     let running = o.actions.length;
     // Safety short circuit in case we somehow start a worker with nothing.
-    running === 0 && o.port.postMessage('');
+    running === 0 && parentPort.postMessage('');
 
     o.actions.forEach(a => {
       fs.copyFile(a.src, a.dest, 0, err => {
         if (err) {
-          o.port.emit('error', err);
+          parentPort.emit('error', err);
         } else {
           running -= 1;
-          running === 0 && o.port.postMessage('');
+          running === 0 && parentPort.postMessage('');
         }
       });
     });
   } catch (e) {
-    o.port.emit('error', e);
+    parentPort.emit('error', e);
   }
 });


### PR DESCRIPTION
It prevents workers to have multiple tasks at the same time.

It also enables implementing some timeout and retry logic when a job fails.