### PR TITLE
Add verbose logging to file copy back

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "midgard-yarn",
   "installationMethod": "unknown",
-  "version": "1.23.16",
+  "version": "1.23.17",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",

--- a/src/reporters/lang/en.js
+++ b/src/reporters/lang/en.js
@@ -45,7 +45,8 @@ const messages = {
     '$0 has dependency $1 with range $2 that collides with a dependency in $3 of the same name with version $4',
   manifestDirectoryNotFound: 'Unable to read $0 directory of module $1',
 
-  verboseFileCopy: 'Copying $0 to $1.',
+  verboseWorkerCompleted: 'Worker $0 / $1 completed.',
+  verboseFileCopy: 'Copying $0 to $1. ($2)',
   verboseFileLink: 'Creating hardlink at $0 to $1.',
   verboseFileSymlink: 'Creating symlink at $0 to $1.',
   verboseFileSkip: 'Skipping copying of file $0 as the file at $1 is the same size ($2) and mtime ($3).',

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -585,6 +585,7 @@ export async function copyBulk(
         reject(err && err.err);
       };
       const onMessage = () => {
+        reporter.verbose(reporter.lang('verboseWorkerCompleted', i, split.length));
         worker.off('error', onError);
         worker.off('close', onError);
         worker.off('message', onMessage);
@@ -597,11 +598,13 @@ export async function copyBulk(
       worker.on('error', onError);
       worker.on('close', onError);
       worker.on('message', onMessage);
-      worker.postMessage({actions: ac.map(a => ({src: a.src, dest: a.dest}))});
+      const actions = ac.map(action => ({src: action.src, dest: action.dest}));
+      actions.forEach(action =>
+        reporter.verbose(reporter.lang('verboseFileCopy', action.src, action.dest, `worker ${i}`)),
+      );
+      worker.postMessage({actions});
     });
-  })
-  .finally(() => workers.forEach(w => w.terminate()));
-
+  }).finally(() => workers.forEach(w => w.terminate()));
 
   // we need to copy symlinks last as they could reference files we were copying
   const symlinkActions: Array<CopySymlinkAction> = actions.symlink;

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -600,7 +600,9 @@ export async function copyBulk(
       worker.on('message', onMessage);
       const actions = ac.map(action => ({src: action.src, dest: action.dest}));
       actions.forEach(action =>
-        reporter.verbose(reporter.lang('verboseFileCopy', action.src, action.dest, `worker ${i}`)),
+        reporter.verbose(
+          reporter.lang('verboseFileCopy', action.src, action.dest, `worker ${i}, total ${actions.length}`),
+        ),
       );
       worker.postMessage({actions});
     });


### PR DESCRIPTION
Add back some functionality of verbose logging lost in worker migration. Also add a logline for when each worker finishes. Hopefully this will help tracking down where the hang is