### PR TITLE
Upgrade mkdirp and create workers after build actions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,6 +19,7 @@
      "plugins": [
        ["array-includes"],
        ["transform-inline-imports-commonjs"],
+       ["transform-object-rest-spread"],
        ["transform-runtime", { "polyfill": true, "regenerator": false }],
        ["transform-builtin-extend", { "globals": ["Error"] }]
      ]
@@ -53,6 +54,7 @@
   ],
   "plugins": [
     ["babel-plugin-inline-import", { "extensions": [ ".tpl.js" ] }],
+    ["transform-object-rest-spread"],
     ["transform-inline-imports-commonjs"],
     ["transform-runtime", { "polyfill": false, "regenerator": true }]
   ]

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "leven": "^2.0.0",
     "loud-rejection": "^1.2.0",
     "micromatch": "^2.3.11",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.0",
     "node-emoji": "^1.6.1",
     "normalize-url": "^2.0.0",
     "npm-logical-tree": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "midgard-yarn",
   "installationMethod": "unknown",
-  "version": "1.23.17",
+  "version": "1.23.18",
   "license": "BSD-2-Clause",
   "preferGlobal": true,
   "description": "📦🐈 Fast, reliable, and secure dependency management.",

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -38,7 +38,7 @@ cp README.md dist/
 cp LICENSE dist/
 # Only use the legacy version for NPM builds so we are compatible
 # with any Node >= 4 and still small in terms of size.
-cp artifacts/yarn-$version.js dist/lib/cli.js
+cp artifacts/yarn-legacy-$version.js dist/lib/cli.js
 cp bin/{yarn.js,yarn,yarnpkg,*.cmd} dist/bin/
 chmod +x dist/bin/*
 

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -38,7 +38,7 @@ cp README.md dist/
 cp LICENSE dist/
 # Only use the legacy version for NPM builds so we are compatible
 # with any Node >= 4 and still small in terms of size.
-cp artifacts/yarn-legacy-$version.js dist/lib/cli.js
+cp artifacts/yarn-$version.js dist/lib/cli.js
 cp bin/{yarn.js,yarn,yarnpkg,*.cmd} dist/bin/
 chmod +x dist/bin/*
 

--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -78,7 +78,7 @@ const compiler = webpack({
     rules: [
       {
         test: /\.js$/,
-        exclude: /Caches/,
+        exclude: /(node_modules[\\\/](?!mkdirp))|Caches/,
         loader: require.resolve('babel-loader')
       },
       {
@@ -130,7 +130,7 @@ const compilerLegacy = webpack({
     rules: [
       {
         test: /\.js$/,
-        exclude: /node_modules[\\\/](?!inquirer)/,
+        exclude: /node_modules[\\\/](?!inquirer|mkdirp)/,
         use: [
           {
             loader:'babel-loader',

--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -78,7 +78,7 @@ const compiler = webpack({
     rules: [
       {
         test: /\.js$/,
-        exclude: /node_modules|Caches/,
+        exclude: /Caches/,
         loader: require.resolve('babel-loader')
       },
       {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -301,7 +301,7 @@ export async function main({
 
     return command.run(config, reporter, commander, commander.args).then(exitCode => {
       if (shouldWrapOutput) {
-        reporter.footer(false);
+        reporter.footer(true);
       }
       return exitCode;
     });

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -548,14 +548,12 @@ export async function copyBulk(
     ignoreBasenames: (_events && _events.ignoreBasenames) || [],
     artifactFiles: (_events && _events.artifactFiles) || [],
   };
-
-  const workers = createWorkers();
-
   const actions: CopyActions = await buildActionsForCopy(queue, events, events.possibleExtraneous, reporter);
   events.onStart(actions.file.length + actions.symlink.length + actions.link.length);
 
   const fileActions: Array<CopyFileAction> = actions.file;
 
+  const workers = createWorkers();
   await new Promise((resolve, reject) => {
     const split = fileActions
       .reduce(

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -8,6 +8,7 @@ import fs from 'fs';
 import globModule from 'glob';
 import os from 'os';
 import path from 'path';
+import mkdirp from 'mkdirp';
 
 import BlockingQueue from './blocking-queue.js';
 import * as promise from './promise.js';
@@ -37,13 +38,12 @@ export const readdir: (path: string, opts: void) => Promise<Array<string>> = pro
 export const rename: (oldPath: string, newPath: string) => Promise<void> = promisify(fs.rename);
 export const access: (path: string, mode?: number) => Promise<void> = promisify(fs.access);
 export const stat: (path: string) => Promise<fs.Stats> = promisify(fs.stat);
-export const mkdirp: (path: string) => Promise<void> = promisify(require('mkdirp'));
 export const exists: (path: string) => Promise<boolean> = promisify(fs.exists, true);
 export const lstat: (path: string) => Promise<fs.Stats> = promisify(fs.lstat);
 export const chmod: (path: string, mode: number | string) => Promise<void> = promisify(fs.chmod);
 export const link: (src: string, dst: string) => Promise<fs.Stats> = promisify(fs.link);
 export const glob: (path: string, options?: Object) => Promise<Array<string>> = promisify(globModule);
-export {unlink};
+export {unlink, mkdirp};
 
 // fs.copyFile uses the native file copying instructions on the system, performing much better
 // than any JS-based solution and consumes fewer resources. Repeated testing to fine tune the

--- a/yarn.lock
+++ b/yarn.lock
@@ -5293,6 +5293,11 @@ mkdirp@*, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
+mkdirp@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 mock-stdin@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-0.3.1.tgz#c657d9642d90786435c64ca5e99bbd4d09bd7dd3"


### PR DESCRIPTION
There is some case which causes yarn fast to hang. To attempt to mitigate these as much as possible, I am:

1. Upgrading to mkdirp >1 to utilities native fs recursive directory making.
2. Spawning workers after the buildactionsforcopy. From investigations, some promise is probably never resolve/rejecting in that function. In that case, the process is staying alive because the workers are already spawned and have handles open

