### PR TITLE
feat: adds support for --ignore-cpu in yarn install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see https://yarnpkg.com/org/contributing/
+Please see https://classic.yarnpkg.com/org/contributing/

--- a/__tests__/package-compatibility.js
+++ b/__tests__/package-compatibility.js
@@ -20,13 +20,28 @@ test('ignore semver prerelease semantics for yarn', () => {
   expect(testEngine('yarn', '^1.3.0', {yarn: '1.4.1-20180208.2355'}, true)).toEqual(true);
 });
 
+test('shouldCheck returns false if the manifest does not specify any requirements', () => {
+  expect(shouldCheck({}, {ignorePlatform: false, ignoreEngines: false, ignoreCpu: false})).toBe(false);
+
+  expect(
+    shouldCheck(
+      {
+        os: [],
+        cpu: [],
+        engines: {},
+      },
+      {ignorePlatform: false, ignoreEngines: false, ignoreCpu: false},
+    ),
+  ).toBe(false);
+});
+
 test('shouldCheck returns true if ignorePlatform is false and the manifest specifies an os or cpu requirement', () => {
   expect(
     shouldCheck(
       {
         os: ['darwin'],
       },
-      {ignorePlatform: false, ignoreEngines: false},
+      {ignorePlatform: false, ignoreEngines: false, ignoreCpu: false},
     ),
   ).toBe(true);
 
@@ -35,19 +50,18 @@ test('shouldCheck returns true if ignorePlatform is false and the manifest speci
       {
         cpu: ['i32'],
       },
-      {ignorePlatform: false, ignoreEngines: false},
+      {ignorePlatform: false, ignoreEngines: false, ignoreCpu: false},
     ),
   ).toBe(true);
+});
 
-  expect(shouldCheck({}, {ignorePlatform: false, ignoreEngines: false})).toBe(false);
-
+test('shouldCheck returns false if the manifest specifies an os or cpu requirement but ignorePlatform is true', () => {
   expect(
     shouldCheck(
       {
-        os: [],
-        cpu: [],
+        os: ['darwin'],
       },
-      {ignorePlatform: false, ignoreEngines: false},
+      {ignorePlatform: true, ignoreEngines: false, ignoreCpu: false},
     ),
   ).toBe(false);
 
@@ -55,9 +69,19 @@ test('shouldCheck returns true if ignorePlatform is false and the manifest speci
     shouldCheck(
       {
         cpu: ['i32'],
-        os: ['darwin'],
       },
-      {ignorePlatform: true, ignoreEngines: false},
+      {ignorePlatform: true, ignoreEngines: false, ignoreCpu: false},
+    ),
+  ).toBe(false);
+});
+
+test('shouldCheck returns false if the manifest specifies a cpu requirement but ignoreCpu is true', () => {
+  expect(
+    shouldCheck(
+      {
+        cpu: ['i32'],
+      },
+      {ignorePlatform: false, ignoreEngines: false, ignoreCpu: true},
     ),
   ).toBe(false);
 });
@@ -68,18 +92,16 @@ test('shouldCheck returns true if ignoreEngines is false and the manifest specif
       {
         engines: {node: '>= 10'},
       },
-      {ignorePlatform: false, ignoreEngines: false},
+      {ignorePlatform: false, ignoreEngines: false, ignoreCpu: false},
     ),
   ).toBe(true);
-
-  expect(shouldCheck({}, {ignorePlatform: false, ignoreEngines: false})).toBe(false);
 
   expect(
     shouldCheck(
       {
         engines: {node: '>= 10'},
       },
-      {ignorePlatform: false, ignoreEngines: true},
+      {ignorePlatform: false, ignoreEngines: true, ignoreCpu: false},
     ),
   ).toBe(false);
 });

--- a/packages/pkg-tests/pkg-tests-specs/sources/basic.js
+++ b/packages/pkg-tests/pkg-tests-specs/sources/basic.js
@@ -406,6 +406,30 @@ module.exports = (makeTemporaryEnv: PackageDriver) => {
     );
 
     test(
+      `it should not fail if the environment does not satisfy the cpu architecture but ignore cpu is true`,
+      makeTemporaryEnv(
+        {
+          cpu: ['unicorn'],
+        },
+        async ({path, run, source}) => {
+          await run(`install`, '--ignore-cpu');
+        },
+      ),
+    );
+
+    test(
+      `it should not fail if the environment does not satisfy the cpu architecture but ignore platform is true`,
+      makeTemporaryEnv(
+        {
+          cpu: ['unicorn'],
+        },
+        async ({path, run, source}) => {
+          await run(`install`, '--ignore-platform');
+        },
+      ),
+    );
+
+    test(
       `it should fail if the environment does not satisfy the engine requirements`,
       makeTemporaryEnv(
         {
@@ -420,7 +444,7 @@ module.exports = (makeTemporaryEnv: PackageDriver) => {
     );
 
     test(
-      `it should not fail if the environment does not satisfy the os and cpu architecture but ignore platform is true`,
+      `it should not fail if the environment does not satisfy the os platform but ignore platform is true`,
       makeTemporaryEnv(
         {
           os: ['unicorn'],

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -20,6 +20,7 @@ const CONFIG_KEYS = [
   'linkFolder',
   'offline',
   'binLinks',
+  'ignoreCpu',
   'ignorePlatform',
   'ignoreScripts',
   'disablePrepublish',

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -55,6 +55,7 @@ export type InstallCwdRequest = {
 type Flags = {
   // install
   har: boolean,
+  ignoreCpu: boolean,
   ignorePlatform: boolean,
   ignoreEngines: boolean,
   ignoreOptional: boolean,
@@ -136,6 +137,7 @@ function normalizeFlags(config: Config, rawFlags: Object): Flags {
   const flags = {
     // install
     har: !!rawFlags.har,
+    ignoreCpu: !!rawFlags.ignoreCpu,
     ignorePlatform: !!rawFlags.ignorePlatform,
     ignoreEngines: !!rawFlags.ignoreEngines,
     ignoreScripts: !!rawFlags.ignoreScripts,
@@ -168,6 +170,10 @@ function normalizeFlags(config: Config, rawFlags: Object): Flags {
 
   if (config.getOption('ignore-scripts')) {
     flags.ignoreScripts = true;
+  }
+
+  if (config.getOption('ignore-cpu')) {
+    flags.ignoreCpu = true;
   }
 
   if (config.getOption('ignore-platform')) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -86,7 +86,8 @@ export async function main({
   commander.option('--json', 'format Yarn log messages as lines of JSON (see jsonlines.org)');
   commander.option('--ignore-scripts', "don't run lifecycle scripts");
   commander.option('--har', 'save HAR output of network traffic');
-  commander.option('--ignore-platform', 'ignore platform checks');
+  commander.option('--ignore-cpu', 'ignore CPU check');
+  commander.option('--ignore-platform', 'ignore platform ("os" and "cpu") checks');
   commander.option('--ignore-engines', 'ignore engines check');
   commander.option('--ignore-optional', 'ignore optional dependencies');
   commander.option('--force', 'install and build packages even if they were built before, overwrite lockfile');
@@ -539,6 +540,7 @@ export async function main({
       binLinks: commander.binLinks,
       preferOffline: commander.preferOffline,
       captureHar: commander.har,
+      ignoreCpu: commander.ignoreCpu,
       ignorePlatform: commander.ignorePlatform,
       ignoreEngines: commander.ignoreEngines,
       ignoreScripts: commander.ignoreScripts,

--- a/src/config.js
+++ b/src/config.js
@@ -38,6 +38,7 @@ export type ConfigOptions = {
   enableMetaFolder?: boolean,
   linkFileDependencies?: boolean,
   captureHar?: boolean,
+  ignoreCpu?: boolean,
   ignoreScripts?: boolean,
   ignorePlatform?: boolean,
   ignoreEngines?: boolean,
@@ -117,6 +118,7 @@ export default class Config {
   enableMetaFolder: boolean;
   enableLockfileVersions: boolean;
   linkFileDependencies: boolean;
+  ignoreCpu: boolean;
   ignorePlatform: boolean;
   binLinks: boolean;
   updateChecksums: boolean;
@@ -474,6 +476,7 @@ export default class Config {
     this.plugnplayUnplugged = [];
     this.plugnplayPurgeUnpluggedPackages = false;
 
+    this.ignoreCpu = !!opts.ignoreCpu;
     this.ignorePlatform = !!opts.ignorePlatform;
     this.ignoreScripts = !!opts.ignoreScripts;
 

--- a/src/package-compatibility.js
+++ b/src/package-compatibility.js
@@ -133,7 +133,7 @@ export function checkOne(info: Manifest, config: Config, ignoreEngines: boolean)
     pushError(reporter.lang('incompatibleOS', process.platform));
   }
 
-  if (shouldCheckCpu(cpu, config.ignorePlatform) && !isValidArch(cpu)) {
+  if (shouldCheckCpu(cpu, config.ignorePlatform, config.ignoreCpu) && !isValidArch(cpu)) {
     pushError(reporter.lang('incompatibleCPU', process.arch));
   }
 
@@ -167,8 +167,12 @@ export function check(infos: Array<Manifest>, config: Config, ignoreEngines: boo
   }
 }
 
-function shouldCheckCpu(cpu: $PropertyType<Manifest, 'cpu'>, ignorePlatform: boolean): boolean %checks {
-  return !ignorePlatform && Array.isArray(cpu) && cpu.length > 0;
+function shouldCheckCpu(
+  cpu: $PropertyType<Manifest, 'cpu'>,
+  ignorePlatform: boolean,
+  ignoreCpu: boolean,
+): boolean %checks {
+  return !(ignorePlatform || ignoreCpu) && Array.isArray(cpu) && cpu.length > 0;
 }
 
 function shouldCheckPlatform(os: $PropertyType<Manifest, 'os'>, ignorePlatform: boolean): boolean %checks {
@@ -176,15 +180,15 @@ function shouldCheckPlatform(os: $PropertyType<Manifest, 'os'>, ignorePlatform: 
 }
 
 function shouldCheckEngines(engines: $PropertyType<Manifest, 'engines'>, ignoreEngines: boolean): boolean %checks {
-  return !ignoreEngines && typeof engines === 'object';
+  return !ignoreEngines && typeof engines === 'object' && Object.keys(engines).length > 0;
 }
 
 export function shouldCheck(
   manifest: PartialManifest,
-  options: {ignoreEngines: boolean, ignorePlatform: boolean},
+  options: {ignoreEngines: boolean, ignorePlatform: boolean, ignoreCpu: boolean},
 ): boolean {
   return (
-    shouldCheckCpu(manifest.cpu, options.ignorePlatform) ||
+    shouldCheckCpu(manifest.cpu, options.ignorePlatform, options.ignoreCpu) ||
     shouldCheckPlatform(manifest.os, options.ignorePlatform) ||
     shouldCheckEngines(manifest.engines, options.ignoreEngines)
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


When cross-compiling a project for a different CPU architecture, e.g. for arm on a x64 machine, the only option to install arch-specific packages is to pass `--ignore-platform`. But that flag also triggers installation of platform-restricted packages not intended to be used on the current platform. Since such packages are always optional their build failures are ignored, but it would be better to not build them at all.

Let's add a new command line flag `--ignore-cpu` to ignore "cpu" restrictions in package.json,
but preserve behaviour of `--ignore-platform` to ignore both "cpu" and "os".

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Existing tests are updated and new ones are added.
