### PR TITLE
Fix HAR file generation

### DIFF
--- a/__tests__/__mocks__/request.js
+++ b/__tests__/__mocks__/request.js
@@ -47,7 +47,12 @@ class Request extends RealRequest {
   }
 }
 
-module.exports = function(params: Object): Request {
+module.exports = function(initialParams: Object, callback?: ?Function): Request {
+  const params = {
+    ...initialParams,
+    ...(callback ? {callback} : {}),
+  };
+
   return new Request(params);
 };
 

--- a/__tests__/commands/_helpers.js
+++ b/__tests__/commands/_helpers.js
@@ -98,6 +98,7 @@ export function makeConfigFromDirectory(cwd: string, reporter: Reporter, flags: 
       enableDefaultRc: !flags.noDefaultRc,
       extraneousYarnrcFiles: flags.useYarnrc,
       modulesFolder: flags.modulesFolder ? path.join(cwd, flags.modulesFolder) : undefined,
+      captureHar: !!flags.har,
     },
     reporter,
   );

--- a/__tests__/commands/install/har.js
+++ b/__tests__/commands/install/har.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+import * as fs from '../../../src/util/fs.js';
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
+
+const request = require('request');
+const path = require('path');
+import {runInstall} from '../_helpers.js';
+
+beforeEach(request.__resetAuthedRequests);
+afterEach(request.__resetAuthedRequests);
+
+async function findHarFile(dir): Promise<string> {
+  const filenames = await fs.readdir(dir);
+  for (const file of filenames) {
+    if (file.endsWith('.har')) {
+      return path.join(dir, file);
+    }
+  }
+  throw new Error('could not find a .har file');
+}
+
+test('--har flag produces a har file with registry requests', () =>
+  runInstall({har: true}, 'install-production', async config => {
+    const harFile = await findHarFile(config.cwd);
+    const contents = await fs.readJson(harFile);
+    expect(contents.log.entries).toHaveLength(2);
+    const urls = contents.log.entries.map(e => e.request.url).sort();
+    expect(urls[0]).toContain('is-array');
+    expect(urls[1]).toContain('left-pad');
+  }));

--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -742,7 +742,7 @@ export class Install {
     if (this.flags.har) {
       steps.push(async (curr: number, total: number) => {
         const formattedDate = new Date().toISOString().replace(/:/g, '-');
-        const filename = `yarn-install_${formattedDate}.har`;
+        const filename = path.join(this.config.cwd, `yarn-install_${formattedDate}.har`);
         this.reporter.step(
           curr,
           total,

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -223,7 +223,7 @@ export default class RequestManager {
   requestWithRacingRetry() {
     const request = require('request');
 
-    const decoratedRequest = params => {
+    const decoratedRequest = (...params) => {
       // Use a buffer stream to make sure the data does not overflow the various streams.
       const bufferStream = new BufferStream();
 
@@ -234,7 +234,7 @@ export default class RequestManager {
       let done = false;
       let aborted = false;
 
-      let req1 = request(params);
+      let req1 = request(...params);
       // We pause the stream so no response data flows out until we call .resume().
       req1.pause();
 
@@ -244,7 +244,7 @@ export default class RequestManager {
         if (done) {
           return;
         }
-        req2 = request(params);
+        req2 = request(...params);
         // We pause the stream so no response data flows out until we call .resume().
         req2.pause();
         req2.on('error', (...args) => {


### PR DESCRIPTION
**Summary**

When the request retry was introduced in this fork, it broke the HAR generation because it didn't pass the optional callback to the request module. This PR fixes that by passing all arguments.

**Test plan**

Added a test that verifies the fix.
