### PR TITLE
don't wrap node command

### DIFF
--- a/src/util/execute-lifecycle-script.js
+++ b/src/util/execute-lifecycle-script.js
@@ -234,7 +234,10 @@ export async function makeEnv(
     env.NODE_OPTIONS = `--require ${pnpFile} ${env.NODE_OPTIONS}`;
   }
 
-  pathParts.unshift(await getWrappersFolder(config));
+  // We don't need to wrap node into a node.cmd file. This was introduced for pnp
+  // but we don't use yarn pnp. This results in the args being parsed 4 times by the
+  // command line instead of two, and this breaks the parsing in special cases.
+  // pathParts.unshift(await getWrappersFolder(config));
 
   // join path back together
   env[constants.ENV_PATH_KEY] = pathParts.join(path.delimiter);


### PR DESCRIPTION
Yarn wraps node executable in a node.cmd file as part of the `yarn run` command.
The result is that the args passed to `yarn run` get parsed by cmd (on Windows) four times instead of two.
This is fine most of the time as args are escaped with double quotes. But sometimes the args can't be escaped with double quotes (eg. the args contains a double quote, or a % sign), when this happens the escaping is done with the ^ character and parsing these args 4 times instead of 2 breaks the command.