### PR TITLE
Add option --error-log-file to customize where yarn-error.log file is written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please add one entry in this file for each change in Yarn's behavior. Use the sa
 
 ## Master
 
+- Add option --error-log-file to customize where yarn-error.log file is written
+
+  [#44](https://github.com/VincentBailly/yarn/pull/44) - [**Danny van Velzen**](https://github.com/dannyvv)
+
 - Passes arguments following `--` when running a workspace script (`yarn workspace pkg run command -- arg`)
 
   [#7776](https://github.com/yarnpkg/yarn/pull/7776) - [**Jeff Valore**](https://twitter.com/rally25rs)

--- a/__tests__/error-log-file.js
+++ b/__tests__/error-log-file.js
@@ -1,0 +1,113 @@
+/* @flow */
+
+import {existsSync} from 'fs';
+
+import NoopReporter from '../src/reporters/base-reporter.js';
+import makeTemp from './_temp';
+import * as fs from '../src/util/fs.js';
+
+const path = require('path');
+const exec = require('child_process').exec;
+
+const fixturesLoc = path.join(__dirname, './fixtures/error-log-file');
+const yarnBin = path.join(__dirname, '../bin/yarn.js');
+
+if (!existsSync(path.resolve(__dirname, '../lib'))) {
+  throw new Error('These tests require `yarn build` to have been run first.');
+}
+
+async function execCommand(
+  cmd: string,
+  args: Array<string>,
+  name: string,
+): Promise<{workingDir: string, stdoutLines: Array<?string>}> {
+  const srcDir = path.join(fixturesLoc, name);
+  const workingDir = await makeTemp(name);
+  await fs.copy(srcDir, workingDir, new NoopReporter());
+
+  const cacheDir = path.join(workingDir, '.yarn-cache');
+
+  return new Promise((resolve, reject) => {
+    const cleanedEnv = {...process.env};
+    cleanedEnv['YARN_SILENT'] = 0;
+    cleanedEnv['YARN_WRAP_OUTPUT'] = 1;
+    delete cleanedEnv['FORCE_COLOR'];
+
+    exec(
+      `node "${yarnBin}" --cache-folder="${cacheDir}" ${cmd} ${args.join(' ')}`,
+      {
+        cwd: workingDir,
+        env: cleanedEnv,
+      },
+      (error, stdout, stderr) => {
+        if (!error) {
+          reject('Expected test to fail, yet no error detected');
+        }
+
+        resolve({
+          workingDir,
+          stdout,
+        });
+      },
+    );
+  });
+}
+
+function expectLogFile(result, expectedErrorFile: string) {
+  expect(existsSync(path.resolve(result.workingDir, expectedErrorFile))).toBeTruthy();
+  expect(result.stdout.replace(/\\\\/g, '\\')).toContain(expectedErrorFile);
+}
+
+test('error-log-file-no-config-no-arg', async () => {
+  const result = await execCommand('add', ['nonExistingPackageForTesting'], 'no-config', true);
+  expectLogFile(result, 'yarn-error.log');
+});
+
+test('error-log-file-no-config-relative-arg', async () => {
+  const result = await execCommand(
+    'add',
+    ['nonExistingPackageForTesting', '--error-log-file', 'relativeFromArg.err'],
+    'no-config',
+    true,
+  );
+  expectLogFile(result, 'relativeFromArg.err');
+});
+
+test('error-log-file-no-config-absolute-arg', async () => {
+  const errorLogDir = await makeTemp('no-config');
+  const errorFile = path.join(errorLogDir, 'absoluteFromArg.err');
+  const result = await execCommand(
+    'add',
+    ['nonExistingPackageForTesting', '--error-log-file', `"${errorFile}"`],
+    'no-config',
+    true,
+  );
+  expectLogFile(result, errorFile);
+});
+
+test('error-log-file-with-config-no-arg', async () => {
+  const result = await execCommand('add', ['nonExistingPackageForTesting'], 'with-config', true);
+  expectLogFile(result, 'fromConfig.txt');
+});
+
+test('error-log-file-with-config-relative-arg', async () => {
+  const result = await execCommand(
+    'add',
+    ['nonExistingPackageForTesting', '--error-log-file', 'relativeFromArg.err'],
+    'with-config',
+    true,
+  );
+  expectLogFile(result, 'relativeFromArg.err');
+});
+
+test('error-log-file-with-config-absolute-arg', async () => {
+  const errorLogDir = await makeTemp('no-config');
+  const errorFile = path.join(errorLogDir, 'absoluteFromArg.err');
+  const result = await execCommand(
+    'add',
+    ['nonExistingPackageForTesting', '--error-log-file', `"${errorFile}"`],
+    'with-config',
+    true,
+  );
+  expectLogFile(result, errorFile);
+});

--- a/__tests__/fixtures/error-log-file/no-config/package.json
+++ b/__tests__/fixtures/error-log-file/no-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}

--- a/__tests__/fixtures/error-log-file/with-config/.yarnrc
+++ b/__tests__/fixtures/error-log-file/with-config/.yarnrc
@@ -1,0 +1,1 @@
+error-log-file: "fromConfig.txt"

--- a/__tests__/fixtures/error-log-file/with-config/package.json
+++ b/__tests__/fixtures/error-log-file/with-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -17,6 +17,7 @@ const CONFIG_KEYS = [
   'preferOffline',
   'modulesFolder',
   'globalFolder',
+  'errorLogFile',
   'linkFolder',
   'offline',
   'binLinks',

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -104,6 +104,10 @@ export async function main({
   commander.option('--link-folder <path>', 'specify a custom folder to store global links');
   commander.option('--global-folder <path>', 'specify a custom folder to store global packages');
   commander.option(
+    '--error-log-file <path>',
+    'specify a custom file path to log error details to when an error occurs',
+  );
+  commander.option(
     '--modules-folder <path>',
     'rather than installing modules into the node_modules folder relative to the cwd, output them here',
   );
@@ -502,9 +506,11 @@ export async function main({
   }
 
   function writeErrorReport(log): ?string {
-    const errorReportLoc = config.enableMetaFolder
-      ? path.join(config.cwd, constants.META_FOLDER, 'yarn-error.log')
-      : path.join(config.cwd, 'yarn-error.log');
+    const errorReportLoc = config.errorLogFile
+      ? path.resolve(config.cwd, config.errorLogFile) // Use resolve to allow for relative and absolute paths
+      : config.enableMetaFolder
+        ? path.join(config.cwd, constants.META_FOLDER, 'yarn-error.log')
+        : path.join(config.cwd, 'yarn-error.log');
 
     try {
       fs.writeFileSync(errorReportLoc, log.join('\n\n') + '\n');
@@ -533,6 +539,7 @@ export async function main({
       cwd,
       commandName,
       ...resolvedFolderOptions,
+      errorLogFile: commander.errorLogFile,
       enablePnp: commander.pnp,
       disablePnp: commander.disablePnp,
       enableDefaultRc: commander.defaultRc,

--- a/src/config.js
+++ b/src/config.js
@@ -53,6 +53,7 @@ export type ConfigOptions = {
   enablePnp?: boolean,
   disablePnp?: boolean,
   offlineCacheFolder?: string,
+  errorLogFile?: string,
 
   enableDefaultRc?: boolean,
   extraneousYarnrcFiles?: Array<string>,
@@ -349,6 +350,11 @@ export default class Config {
     this.globalFolder = opts.globalFolder || String(this.getOption('global-folder', true));
     if (this.globalFolder === 'undefined') {
       this.globalFolder = constants.GLOBAL_MODULE_DIRECTORY;
+    }
+
+    this.errorLogFile = opts.errorLogFile || String(this.getOption('error-log-file', true));
+    if (this.errorLogFile === 'undefined') {
+      this.errorLogFile = undefined;
     }
 
     let cacheRootFolder = opts.cacheFolder || this.getOption('cache-folder', true);


### PR DESCRIPTION
**Summary**
This change adds a command line flag and a config option to redirect the default yarn-error.log that gets written with more details when a command fails.

The motivation for this feature is that in large repo's policies exist not to write to the source tree during build. All logs and intermediate files should go to separate log roots and intermediate roots. This is to aid in version control performance and validation machine cleanliness.

The previous file was simply hard coded to go to the working directory, or an optional relative meta directory which was also not configurable but has an impact on other files.

**Test plan**

I added tests and made sure linting passes for the editted files. To run the tests \worker.js needs to be copied to \src\worker.js