### PR TITLE
Fix EsLint rule violations

### DIFF
--- a/src/cli/commands/install.js
+++ b/src/cli/commands/install.js
@@ -1226,6 +1226,7 @@ export async function run(config: Config, reporter: Reporter, flags: Object, arg
 
   // Let time for all the output to be printed and then hard exit.
   // This fixes an issue where a hanging request would keep node alive.
+  // eslint-disable-next-line no-process-exit
   setTimeout(() => process.exit(process.exitCode || 0), 1000);
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -17,7 +17,6 @@ import {registries, registryNames} from './registries/index.js';
 import {NoopReporter} from './reporters/index.js';
 import map from './util/map.js';
 
-const crypto = require('crypto');
 const detectIndent = require('detect-indent');
 const invariant = require('invariant');
 const path = require('path');

--- a/src/lockfile/index.js
+++ b/src/lockfile/index.js
@@ -180,7 +180,6 @@ export default class Lockfile {
     }
 
     if (lockfile && lockfile.__metadata) {
-      const lockfilev2 = lockfile;
       lockfile = {};
     }
 

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -14,7 +14,7 @@ import BlockingQueue from './blocking-queue.js';
 import * as promise from './promise.js';
 import {promisify} from './promise.js';
 import map from './map.js';
-import {copyFile, fileDatesEqual, unlink} from './fs-normalized.js';
+import {fileDatesEqual, unlink} from './fs-normalized.js';
 
 export const constants =
   typeof fs.constants !== 'undefined'
@@ -513,14 +513,16 @@ export function copy(src: string, dest: string, reporter: Reporter): Promise<voi
   return copyBulk([{src, dest}], reporter);
 }
 
-const { Worker } = require('worker_threads');
-function spawnWorker() {
-    return new Worker(require('path').join(__dirname, '..', 'worker.js'));
+const {Worker} = require('worker_threads');
+function spawnWorker(): Worker {
+  return new Worker(require('path').join(__dirname, '..', 'worker.js'));
 }
 
-const numberOfWorkers = process.env.WORKERS_LIMIT ? parseInt(process.env.WORKERS_LIMIT) : Math.ceil(os.cpus().length/ 2)
+const numberOfWorkers = process.env.WORKERS_LIMIT
+  ? parseInt(process.env.WORKERS_LIMIT, 10)
+  : Math.ceil(os.cpus().length / 2);
 
-export function createWorkers() {
+export function createWorkers(): Array<Worker> {
   const workers = [];
 
   for (let i = 0; i < numberOfWorkers; i++) {

--- a/src/util/generate-pnp-map.js
+++ b/src/util/generate-pnp-map.js
@@ -248,12 +248,10 @@ async function getPackageInformationStores(
 
         switch (ref.remote.type) {
           case 'workspace':
-            {
-              symlinkSource = loc;
-              symlinkFile = path.resolve(config.lockfileFolder, '.pnp', 'workspaces', `pnp-${hash}`, packageName);
+            symlinkSource = loc;
+            symlinkFile = path.resolve(config.lockfileFolder, '.pnp', 'workspaces', `pnp-${hash}`, packageName);
 
-              loc = symlinkFile;
-            }
+            loc = symlinkFile;
             break;
 
           default:


### PR DESCRIPTION
**Summary**

This fork had a few eslint errors creep in. This PR addresses all the eslint errors.

There are still flow typechecking errors after this, hopefully I can help with this in a future PR.

**Test plan**

Ran `yarn lint` and `node_modules/.bin/eslint .`