### PR TITLE
Add an option to customize yarn meta folder

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -103,6 +103,8 @@ export async function main({
   commander.option('--link-duplicates', 'create hardlinks to the repeated modules in node_modules');
   commander.option('--link-folder <path>', 'specify a custom folder to store global links');
   commander.option('--global-folder <path>', 'specify a custom folder to store global packages');
+  commander.option('--enable-meta-folder', 'enable storing .yarn-integrity file in Yarn meta folder');
+  commander.option('--meta-folder <path>', 'specify a custom folder for storing .yarn-integrity file');
   commander.option(
     '--error-log-file <path>',
     'specify a custom file path to log error details to when an error occurs',
@@ -508,9 +510,10 @@ export async function main({
   function writeErrorReport(log): ?string {
     const errorReportLoc = config.errorLogFile
       ? path.resolve(config.cwd, config.errorLogFile) // Use resolve to allow for relative and absolute paths
-      : config.enableMetaFolder
-        ? path.join(config.cwd, constants.META_FOLDER, 'yarn-error.log')
-        : path.join(config.cwd, 'yarn-error.log');
+      : path.resolve(config.enableMetaFolder
+                        ? (config.metaFolder || path.join(config.cwd, constants.META_FOLDER))
+                        : config.cwd,
+                    'yarn-error.log');
 
     try {
       fs.writeFileSync(errorReportLoc, log.join('\n\n') + '\n');
@@ -524,7 +527,7 @@ export async function main({
 
   const cwd = command.shouldRunInCurrentCwd ? commander.cwd : findProjectRoot(commander.cwd);
 
-  const folderOptionKeys = ['linkFolder', 'globalFolder', 'preferredCacheFolder', 'cacheFolder', 'modulesFolder'];
+  const folderOptionKeys = ['linkFolder', 'globalFolder', 'preferredCacheFolder', 'cacheFolder', 'modulesFolder', 'metaFolder'];
 
   // Resolve all folder options relative to cwd
   const resolvedFolderOptions = {};
@@ -539,6 +542,7 @@ export async function main({
       cwd,
       commandName,
       ...resolvedFolderOptions,
+      enableMetaFolder: commander.enableMetaFolder,
       errorLogFile: commander.errorLogFile,
       enablePnp: commander.pnp,
       disablePnp: commander.disablePnp,

--- a/src/config.js
+++ b/src/config.js
@@ -35,6 +35,7 @@ export type ConfigOptions = {
   preferOffline?: boolean,
   pruneOfflineMirror?: boolean,
   enableMetaFolder?: boolean,
+  metaFolder?: string,
   linkFileDependencies?: boolean,
   captureHar?: boolean,
   ignoreCpu?: boolean,
@@ -125,6 +126,8 @@ export default class Config {
 
   // cache packages in offline mirror folder as new .tgz files
   packBuiltPackages: boolean;
+
+  metaFolder: string;
 
   //
   linkedModules: Array<string>;
@@ -427,7 +430,8 @@ export default class Config {
     this.offlineCacheFolder = String(this.getOption('offline-cache-folder') || '') || null;
 
     this.pruneOfflineMirror = Boolean(this.getOption('yarn-offline-mirror-pruning'));
-    this.enableMetaFolder = Boolean(this.getOption('enable-meta-folder'));
+    this.enableMetaFolder = opts.enableMetaFolder || Boolean(this.getOption('enable-meta-folder'));
+
     this.enableLockfileVersions = Boolean(this.getOption('yarn-enable-lockfile-versions'));
     this.linkFileDependencies = Boolean(this.getOption('yarn-link-file-dependencies'));
     this.packBuiltPackages = Boolean(this.getOption('experimental-pack-script-packages-in-mirror'));
@@ -475,6 +479,7 @@ export default class Config {
     this.preferOffline = !!opts.preferOffline;
     this.modulesFolder = opts.modulesFolder;
     this.linkFolder = opts.linkFolder || constants.LINK_REGISTRY_DIRECTORY;
+    this.metaFolder = opts.metaFolder;
     this.offline = !!opts.offline;
     this.binLinks = !!opts.binLinks;
     this.updateChecksums = !!opts.updateChecksums;

--- a/src/integrity-checker.js
+++ b/src/integrity-checker.js
@@ -98,7 +98,7 @@ export default class InstallationIntegrityChecker {
     if (this.config.modulesFolder) {
       return this.config.modulesFolder;
     } else if (this.config.enableMetaFolder) {
-      return path.join(this.config.lockfileFolder, constants.META_FOLDER);
+      return this.config.metaFolder || path.join(this.config.lockfileFolder, constants.META_FOLDER);
     } else {
       return path.join(this.config.lockfileFolder, constants.NODE_MODULES_FOLDER);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? Please use https://github.com/yarnpkg/rfcs -->

`yarn` already supports writing `.yarn-integrity` file to yarn meta folder. This change allows the meta folder location to be configurable via a command line arg. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This allows `yarn check` to be run an integrity file saved in custom location. 

<!-- Don't forget to update the CHANGELOG.md to quickly describe your changes to other users! -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
